### PR TITLE
bug fixes for sensitivity analyses

### DIFF
--- a/analysis/07d_an_multivariable_cox_models_FULL_Sense3.do
+++ b/analysis/07d_an_multivariable_cox_models_FULL_Sense3.do
@@ -82,7 +82,7 @@ stcox 	i.`exposure_type'			///
 			, strata(stp) vce(cluster household_id)
 if _rc==0{
 estimates
-estimates save ./output/an_sense_`outcome'_CCeth_bmi_smok_ageband_`x', replace
+estimates save ./output/an_sense_`outcome'_CCbmi_smok_ageband_`x', replace
 *estat concordance /*c-statistic*/
  }
  else di "WARNING CC BMI SMOK MODEL WITH AGESPLINE DID NOT FIT (OUTCOME `outcome')" 

--- a/analysis/12_an_tablecontent_HRtable_SENSE.do
+++ b/analysis/12_an_tablecontent_HRtable_SENSE.do
@@ -19,7 +19,7 @@ prog define outputHRsforvar
 syntax, variable(string) min(real) max(real) outcome(string)
 forvalues x=0/1 {
 file write tablecontents_sense ("age") ("`x'") _n
-foreach sense in AAmain CCeth_bmi_smok plus_eth_12mo age_underlying_timescale time_int {
+foreach sense in AAmain CCeth_not_adj_eth CCeth_bmi_smok CCbmi_smok plus_eth_12mo age_underlying_timescale time_int {
 file write tablecontents_sense _n ("sense=") ("`sense'") _n
 forvalues i=1/2 {
 local endwith "_tab"


### PR DESCRIPTION
According to the descriptions:
` *_Sense2.do`  is complete data for bmi smoking and ethnicity `./output/an_sense_covid_death_CCeth_bmi_smok_ageband_*`

` *_Sense3.do ` is complete data for bmi and smoking so I've changed the output name on this one to:  .`/output/an_sense_covid_death_CCbmi_smok_ageband_*`

 In the HR table do file I've added "`CCbmi_smok`" to loop at the top and also "`CC_eth_not_adj_eth`" as this is a sensitivity analysis where the results didn't seem to be being picked up. 